### PR TITLE
[Gdk] Don't crash when turning screen off

### DIFF
--- a/gdk/quartz/gdkevents-quartz.c
+++ b/gdk/quartz/gdkevents-quartz.c
@@ -1847,7 +1847,7 @@ gdk_event_translate (GdkEvent *event,
         NSView *tmp_view = [nswindow firstResponder];
         gboolean gtk_child = FALSE;
 
-        if (event_type == NSKeyDown && ([nsevent modifierFlags] & NSCommandKeyMask) != 0 && [[nsevent characters] characterAtIndex:0] == 'z')
+        if (event_type == NSKeyDown && ([nsevent modifierFlags] & NSCommandKeyMask) != 0 && [[nsevent characters] length] > 0 && [[nsevent characters] characterAtIndex:0] == 'z')
           {
             if ([tmp_view respondsToSelector:@selector(undoManager)])
               {


### PR DESCRIPTION
Check the length of characters in the NSFlagsChanged event before accessing
the individual characters because cmd+alt+power key doesn't have any characters
so an ObjC will throw an exception.

Fixes BXC #41657
