### PR TITLE
[Gdk] Prevent GdkQuartzWindow having its delegate replaced. (#90)

### DIFF
--- a/gdk/quartz/GdkQuartzWindow.c
+++ b/gdk/quartz/GdkQuartzWindow.c
@@ -24,6 +24,13 @@
 
 @implementation GdkQuartzWindow
 
+-(void)dealloc
+{
+  // During deallocation, Cocoa resets the delegate to nil
+  // We need to track that so that we don't throw an error
+  _allowDelegateToBeSetToNil = YES;
+}
+
 -(BOOL)windowShouldClose:(id)sender
 {
   GdkWindow *window = [[self contentView] gdkWindow];
@@ -259,6 +266,16 @@
   return [super makeFirstResponder:responder];
 }
 
+-(void)setDelegate:(id<NSWindowDelegate>)delegate
+{
+  if ([super delegate] == nil || (_allowDelegateToBeSetToNil && delegate == nil)) {
+    [super setDelegate:delegate];
+  } else {
+    // If we allow the window delegate to be replaced, everything breaks.
+    g_critical ("Setting a delegate on GdkQuartzWindow is forbidden, because everything will break.");
+  }
+}
+
 -(id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag screen:(NSScreen *)screen
 {
   self = [super initWithContentRect:contentRect
@@ -271,6 +288,7 @@
   [self setDelegate:self];
   [self setReleasedWhenClosed:YES];
 
+  _allowDelegateToBeSetToNil = NO;
   return self;
 }
 

--- a/gdk/quartz/GdkQuartzWindow.h
+++ b/gdk/quartz/GdkQuartzWindow.h
@@ -34,6 +34,8 @@
   NSPoint initialMoveLocation;
   NSPoint initialResizeLocation;
   NSRect  initialResizeFrame;
+
+  BOOL    _allowDelegateToBeSetToNil;
 }
 
 -(BOOL)isInMove;


### PR DESCRIPTION
Replacing the GdkQuartzWindow delegate causes bad things to happen. This
will prevent it, and drop a message to console telling you not to.

[Gtk] Allow Cocoa to unset the delegate when deallocating the window (#105)

Cocoa unsets delegates when deallocating the window object, so we need to
allow that and not throw a critical message at that point.

Fixes VSTS #935204 and #935386