### PR TITLE
[Gtk] Add a hook for the client to override GtkComboBox menus (#93)

### DIFF
--- a/gtk/gtkcombobox.c
+++ b/gtk/gtkcombobox.c
@@ -227,6 +227,8 @@ enum {
   MOVE_ACTIVE,
   POPUP,
   POPDOWN,
+  SHOW_POPUP,
+  HIDE_POPUP,
   LAST_SIGNAL
 };
 
@@ -627,6 +629,15 @@ gtk_combo_box_class_init (GtkComboBoxClass *klass)
                                 NULL, NULL,
                                 g_cclosure_marshal_VOID__VOID,
                                 G_TYPE_NONE, 0);
+
+  combo_box_signals[SHOW_POPUP] =
+    g_signal_new (I_("xamarin-private-show-native-menu"),
+                  G_OBJECT_CLASS_TYPE (klass),
+                  G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE,
+                  0, _gtk_boolean_handled_accumulator, NULL,
+                  _gtk_marshal_BOOLEAN__VOID,
+                  G_TYPE_BOOLEAN, 0);
+
   /**
    * GtkComboBox::popdown:
    * @button: the object which received the signal
@@ -647,6 +658,14 @@ gtk_combo_box_class_init (GtkComboBoxClass *klass)
                                 NULL, NULL,
                                 _gtk_marshal_BOOLEAN__VOID,
                                 G_TYPE_BOOLEAN, 0);
+
+  combo_box_signals[HIDE_POPUP] =
+    g_signal_new (I_("xamarin-private-hide-native"),
+                  G_OBJECT_CLASS_TYPE (klass),
+                  G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE,
+                  0, _gtk_boolean_handled_accumulator, NULL,
+                  _gtk_marshal_BOOLEAN__VOID,
+                  G_TYPE_BOOLEAN, 0);
 
   /* key bindings */
   binding_set = gtk_binding_set_by_class (widget_class);
@@ -2008,6 +2027,20 @@ update_menu_sensitivity (GtkComboBox *combo_box,
   g_list_free (children);
 }
 
+/* Offer the client a chance to handle menu popups themselves
+   For example, if a native menu was to be used instead of Gtk
+
+   If the client connects to the xamrin-private-show-menu signal
+   they should return TRUE if the native menu was shown
+*/
+static gboolean
+maybe_popup_native_menu (GtkComboBox *combo_box)
+{
+  gboolean retval = FALSE;
+  g_signal_emit (combo_box, combo_box_signals[SHOW_POPUP], 0, &retval);
+  return retval;
+}
+
 static void 
 gtk_combo_box_menu_popup (GtkComboBox *combo_box,
 			  guint        button, 
@@ -2019,6 +2052,11 @@ gtk_combo_box_menu_popup (GtkComboBox *combo_box,
   GtkRequisition requisition;
   gint width;
   
+  if (maybe_popup_native_menu (combo_box))
+  {
+    return;
+  }
+
   update_menu_sensitivity (combo_box, priv->popup_widget);
 
   active_item = -1;
@@ -2118,6 +2156,11 @@ gtk_combo_box_real_popup (GtkComboBox *combo_box)
 
   if (!gtk_widget_get_realized (GTK_WIDGET (combo_box)))
     return;
+
+  if (maybe_popup_native_menu (combo_box))
+  {
+    return;
+  }
 
   if (gtk_widget_get_mapped (priv->popup_widget))
     return;


### PR DESCRIPTION
Adds hooks to our Mac version of Gtk that the client can use to handle combo box menus.

Like this.
![native-combo](https://user-images.githubusercontent.com/1253364/55168794-64712d00-516b-11e9-89dd-96777e38cc9b.gif)